### PR TITLE
Find Episode PID

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,21 @@ const subtitleUri = process.argv[2];
 //   return;
 // }
 
+const versionPid = /^.+_(\w+)_\d+.xml/.exec(subtitleUri)[1];
+console.log("Version PID: " + versionPid);
+
+request({
+    url: 'http://www.bbc.co.uk/programmes/' + versionPid,
+    followRedirect: false
+  }, (err, res, body) => {
+    let redirectUrl = res.headers.location.split('/');
+    episodePidFound(redirectUrl[redirectUrl.length - 1]);
+  });
+
+function episodePidFound(episodePid) {
+  console.log("Episode PID: " + episodePid);
+}
+
 function stripTagsFromString(string) {
   const stringWithoutTags = string
     .replace(/\<br \/\>/g, ' ')


### PR DESCRIPTION
This does two things:

It picks the Version PID out of the subtitles URL using a regex.

It then calls /programmes with the Version PID, without following the redirect, and pulls the Episode PID out of the redirect URL (`res.headers.location`)

It makes a call to another function, supplying that Episode PID. We'd want to put the rest of the functionality inside that function, knowing that we've already got the Episode PID.

Please check my `const` and `let` .. i'm not a Javascript programmer 🤕