### PR TITLE
Convert times to number of seconds.

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,6 +29,17 @@ function stripTagsFromString(string) {
     const subtitleJson = parser.toJson(subtitleString);
     const subtitleContents = JSON.parse(subtitleJson).tt.body.div.p;
 
-    console.log(subtitleContents);
+    subtitleContents.forEach((subtitle) => {
+      console.log(timeInSeconds(subtitle.begin));
+      console.log(subtitle.$t);
+      console.log();
+    });
   // });
 });
+
+function timeInSeconds(time) {
+  let times = time.split(':');
+  return parseInt(times[0]) * 60 * 60
+    + parseInt(times[1]) * 60
+    + parseInt(times[2]);
+}


### PR DESCRIPTION
A useful function for taking a time (eg "00:57:20.92") and converting it to seconds (eg 3440). We'll want to use this when we write to the database.